### PR TITLE
added cases diff_opt_2, km_opt_1/2/3, and nest_starts_later to build.csh

### DIFF
--- a/build.csh
+++ b/build.csh
@@ -54,7 +54,7 @@ if      ( $TEST_GEN == ALL ) then
 
 	set TEST      = ( \
 	                  "em_chem        1 2 5 " \
-	                  "restartA       basic dfi " \
+	                  "restartA       basic dfi diff_opt_2 km_opt_1 km_opt_2 km_opt_3 nest_starts_later " \
 	                  "em_realA       03 03DF " \
 	                  "em_realC       17 17AD 18 20 20NE " \
 	                  "em_realK       52FD 60 60NE " \
@@ -93,7 +93,7 @@ else if ( $TEST_GEN == SOME ) then
 
 	set TEST      = ( \
 	                  "em_chem        1 2 5 " \
-	                  "restartA       basic dfi " \
+	                  "restartA       basic dfi diff_opt_2 km_opt_1 km_opt_2 km_opt_3 nest_starts_later " \
 	                  "em_realA       03 03DF " \
 	                  "em_realC       17 18 20 " \
 	                  "em_realK       52FD 60 60NE " \


### PR DESCRIPTION
Added to the build.csh script to include new feature tests for diff_opt=2, km_opt=1,2,3, and nest starts later. 
These coincide with [PR#3 in wrf_feature_testing](https://github.com/davegill/wrf_feature_testing/pull/3).